### PR TITLE
fix(backend): 같은 이름의 카테고리, 태그, 북마크 엔티티 중복 생성 되지 않도록 수정 (#148)

### DIFF
--- a/backend/core/src/main/java/com/woowacourse/taggle/tag/service/BookmarkService.java
+++ b/backend/core/src/main/java/com/woowacourse/taggle/tag/service/BookmarkService.java
@@ -29,7 +29,7 @@ public class BookmarkService {
         final User user = userService.findById(sessionUser.getId());
 
         final Bookmark bookmark = bookmarkRepository.findByUrlAndUserId(bookmarkCreateDto.getUrl(), user.getId())
-                .orElse(bookmarkRepository.save(bookmarkCreateDto.toEntityWithUser(user)));
+                .orElseGet(() -> bookmarkRepository.save(bookmarkCreateDto.toEntityWithUser(user)));
 
         return BookmarkResponse.of(bookmark);
     }

--- a/backend/core/src/main/java/com/woowacourse/taggle/tag/service/CategoryService.java
+++ b/backend/core/src/main/java/com/woowacourse/taggle/tag/service/CategoryService.java
@@ -31,7 +31,7 @@ public class CategoryService {
 
         final Category category = categoryRepository.findByTitleAndUserId(categoryRequest.getTitle(),
                 sessionUser.getId())
-                .orElse(categoryRepository.save(categoryRequest.toEntityWithUser(user)));
+                .orElseGet(() -> categoryRepository.save(categoryRequest.toEntityWithUser(user)));
 
         return CategoryResponse.of(category);
     }

--- a/backend/core/src/main/java/com/woowacourse/taggle/tag/service/TagService.java
+++ b/backend/core/src/main/java/com/woowacourse/taggle/tag/service/TagService.java
@@ -27,7 +27,7 @@ public class TagService {
     public TagResponse createTag(final SessionUser sessionUser, final TagCreateRequest tagCreateRequest) {
         final User user = userService.findById(sessionUser.getId());
         final Tag tag = tagRepository.findByName(tagCreateRequest.getName())
-                .orElse(tagRepository.save(tagCreateRequest.toEntityWithUser(user)));
+                .orElseGet(() -> tagRepository.save(tagCreateRequest.toEntityWithUser(user)));
 
         return TagResponse.of(tag);
     }

--- a/backend/core/src/test/java/com/woowacourse/taggle/fixture/UserFixture.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/fixture/UserFixture.java
@@ -1,4 +1,4 @@
-package com.woowacourse.taggle.setup.domain;
+package com.woowacourse.taggle.fixture;
 
 import com.woowacourse.taggle.user.domain.Role;
 import com.woowacourse.taggle.user.domain.User;

--- a/backend/core/src/test/java/com/woowacourse/taggle/setup/domain/UserFixture.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/setup/domain/UserFixture.java
@@ -1,0 +1,15 @@
+package com.woowacourse.taggle.setup.domain;
+
+import com.woowacourse.taggle.user.domain.Role;
+import com.woowacourse.taggle.user.domain.User;
+
+public class UserFixture {
+
+    public static final User DEFAULT_USER = User.builder()
+            .id(1L)
+            .email("jordyLover@kakao.com")
+            .nickName("tigger")
+            .role(Role.USER)
+            .picture("https://www.naver.com/")
+            .build();
+}

--- a/backend/core/src/test/java/com/woowacourse/taggle/tag/domain/BookmarkTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/tag/domain/BookmarkTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.woowacourse.taggle.setup.domain.UserFixture;
-import com.woowacourse.taggle.user.domain.Role;
 import com.woowacourse.taggle.user.domain.User;
 
 class BookmarkTest {

--- a/backend/core/src/test/java/com/woowacourse/taggle/tag/domain/BookmarkTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/tag/domain/BookmarkTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.woowacourse.taggle.setup.domain.UserFixture;
 import com.woowacourse.taggle.user.domain.Role;
 import com.woowacourse.taggle.user.domain.User;
 
@@ -15,13 +16,7 @@ class BookmarkTest {
     @DisplayName("constructor: url을 입력받아 북마크를 생성한다.")
     @Test
     void constructor() {
-        User user = User.builder()
-                .id(1L)
-                .email("a@a.com")
-                .nickName("tigger")
-                .role(Role.USER)
-                .picture("https://www.naver.com/")
-                .build();
+        User user = UserFixture.DEFAULT_USER;
 
         assertThat(new Bookmark(URL, user, "title", "description", "image")).isInstanceOf(Bookmark.class);
     }

--- a/backend/core/src/test/java/com/woowacourse/taggle/tag/domain/BookmarkTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/tag/domain/BookmarkTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import com.woowacourse.taggle.setup.domain.UserFixture;
+import com.woowacourse.taggle.fixture.UserFixture;
 import com.woowacourse.taggle.user.domain.User;
 
 class BookmarkTest {

--- a/backend/core/src/test/java/com/woowacourse/taggle/tag/domain/CategoryTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/tag/domain/CategoryTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.woowacourse.taggle.setup.domain.UserFixture;
-import com.woowacourse.taggle.user.domain.Role;
 import com.woowacourse.taggle.user.domain.User;
 
 class CategoryTest {

--- a/backend/core/src/test/java/com/woowacourse/taggle/tag/domain/CategoryTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/tag/domain/CategoryTest.java
@@ -5,21 +5,16 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.woowacourse.taggle.setup.domain.UserFixture;
 import com.woowacourse.taggle.user.domain.Role;
 import com.woowacourse.taggle.user.domain.User;
 
-public class CategoryTest {
+class CategoryTest {
 
     @DisplayName("constructor: 카테고리를 생성한다.")
     @Test
     void constructor() {
-        final User user = User.builder()
-                .id(1L)
-                .email("a@a.com")
-                .nickName("tigger")
-                .role(Role.USER)
-                .picture("https://www.naver.com/")
-                .build();
+        final User user = UserFixture.DEFAULT_USER;
 
         assertThat(new Category("project", user)).isInstanceOf(Category.class);
     }

--- a/backend/core/src/test/java/com/woowacourse/taggle/tag/domain/CategoryTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/tag/domain/CategoryTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import com.woowacourse.taggle.setup.domain.UserFixture;
+import com.woowacourse.taggle.fixture.UserFixture;
 import com.woowacourse.taggle.user.domain.User;
 
 class CategoryTest {

--- a/backend/core/src/test/java/com/woowacourse/taggle/tag/domain/TagTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/tag/domain/TagTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.woowacourse.taggle.setup.domain.UserFixture;
-import com.woowacourse.taggle.user.domain.Role;
 import com.woowacourse.taggle.user.domain.User;
 
 class TagTest {

--- a/backend/core/src/test/java/com/woowacourse/taggle/tag/domain/TagTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/tag/domain/TagTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.woowacourse.taggle.setup.domain.UserFixture;
 import com.woowacourse.taggle.user.domain.Role;
 import com.woowacourse.taggle.user.domain.User;
 
@@ -13,13 +14,7 @@ class TagTest {
     @DisplayName("constructor: 태그를 생성한다.")
     @Test
     void constructor() {
-        User user = User.builder()
-                .id(1L)
-                .email("a@a.com")
-                .nickName("tigger")
-                .role(Role.USER)
-                .picture("https://www.naver.com/")
-                .build();
+        User user = UserFixture.DEFAULT_USER;
 
         assertThat(new Tag("taggle", user)).isInstanceOf(Tag.class);
     }

--- a/backend/core/src/test/java/com/woowacourse/taggle/tag/domain/TagTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/tag/domain/TagTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import com.woowacourse.taggle.setup.domain.UserFixture;
+import com.woowacourse.taggle.fixture.UserFixture;
 import com.woowacourse.taggle.user.domain.User;
 
 class TagTest {

--- a/backend/core/src/test/java/com/woowacourse/taggle/tag/service/BookmarkServiceTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/tag/service/BookmarkServiceTest.java
@@ -14,12 +14,12 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.woowacourse.taggle.JpaTestConfiguration;
+import com.woowacourse.taggle.setup.domain.UserFixture;
 import com.woowacourse.taggle.tag.domain.BookmarkRepository;
 import com.woowacourse.taggle.tag.dto.BookmarkCreateDto;
 import com.woowacourse.taggle.tag.dto.BookmarkResponse;
 import com.woowacourse.taggle.tag.dto.BookmarkTagResponse;
 import com.woowacourse.taggle.tag.exception.BookmarkNotFoundException;
-import com.woowacourse.taggle.user.domain.Role;
 import com.woowacourse.taggle.user.domain.User;
 import com.woowacourse.taggle.user.dto.SessionUser;
 import com.woowacourse.taggle.user.service.UserService;
@@ -42,12 +42,7 @@ class BookmarkServiceTest {
 
     @BeforeEach
     void setUp() {
-        final User testUser = userService.save(User.builder()
-                .email("a@a.com")
-                .nickName("tigger")
-                .role(Role.USER)
-                .picture("https://www.naver.com/")
-                .build());
+        final User testUser = userService.save(UserFixture.DEFAULT_USER);
         user = new SessionUser(testUser);
     }
 

--- a/backend/core/src/test/java/com/woowacourse/taggle/tag/service/BookmarkServiceTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/tag/service/BookmarkServiceTest.java
@@ -14,7 +14,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.woowacourse.taggle.JpaTestConfiguration;
-import com.woowacourse.taggle.setup.domain.UserFixture;
+import com.woowacourse.taggle.fixture.UserFixture;
 import com.woowacourse.taggle.tag.domain.BookmarkRepository;
 import com.woowacourse.taggle.tag.dto.BookmarkCreateDto;
 import com.woowacourse.taggle.tag.dto.BookmarkResponse;
@@ -60,7 +60,7 @@ class BookmarkServiceTest {
         assertThat(bookmarkResponse.getUrl()).isEqualTo("https://taggle.co.kr");
     }
 
-    @DisplayName("이미 같은 이름의 url을 가진 북마크가 존재 하는 경우, 기존의 북마크를 반환한다.")
+    @DisplayName("createBookmark: 이미 같은 이름의 url을 가진 북마크가 존재 하는 경우, 기존의 북마크를 반환한다.")
     @Test
     void createBookmark_DuplicateBookmark_ExceptionThrown() {
         // given
@@ -109,7 +109,7 @@ class BookmarkServiceTest {
         assertThat(bookmarks).hasSize(1);
     }
 
-    @DisplayName("북마크를 삭제한다.")
+    @DisplayName("removeBookmark: 북마크를 삭제한다.")
     @Test
     void removeBookmark() {
         // given
@@ -124,7 +124,7 @@ class BookmarkServiceTest {
         assertThat(bookmarkResponses).hasSize(0);
     }
 
-    @DisplayName("삭제하려는 북마크가 존재 하지 않을 경우 익셉션을 발생한다")
+    @DisplayName("removeBookmark: 삭제하려는 북마크가 존재 하지 않을 경우 익셉션을 발생한다")
     @Test
     void removeBookmark_NotFoundException() {
         // given

--- a/backend/core/src/test/java/com/woowacourse/taggle/tag/service/BookmarkServiceTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/tag/service/BookmarkServiceTest.java
@@ -60,7 +60,7 @@ class BookmarkServiceTest {
         assertThat(bookmarkResponse.getUrl()).isEqualTo("https://taggle.co.kr");
     }
 
-    @DisplayName("동일한 북마크가 이미 존재 할 경우 이미 존재하는 북마크를 반환한다.")
+    @DisplayName("이미 같은 이름의 url을 가진 북마크가 존재 하는 경우, 기존의 북마크를 반환한다.")
     @Test
     void createBookmark_DuplicateBookmark_ExceptionThrown() {
         // given
@@ -69,9 +69,14 @@ class BookmarkServiceTest {
 
         // when
         final BookmarkResponse bookmarkResponse = bookmarkService.createBookmark(user, bookmarkCreateRequest);
+        final BookmarkResponse bookmarkResponseWithSameName = bookmarkService.createBookmark(user, bookmarkCreateRequest);
 
         // then
-        assertThat(bookmarkResponse.getUrl()).isEqualTo("https://taggle.co.kr");
+        assertThat(bookmarkResponse.getId()).isEqualTo(bookmarkResponseWithSameName.getId());
+        assertThat(bookmarkResponse.getUrl()).isEqualTo(bookmarkResponseWithSameName.getUrl());
+        assertThat(bookmarkResponse.getTitle()).isEqualTo(bookmarkResponseWithSameName.getTitle());
+        assertThat(bookmarkResponse.getDescription()).isEqualTo(bookmarkResponseWithSameName.getDescription());
+        assertThat(bookmarkResponse.getImage()).isEqualTo(bookmarkResponseWithSameName.getImage());
     }
 
     @DisplayName("findBookmark: 하나의 북마크를 조회한다.")

--- a/backend/core/src/test/java/com/woowacourse/taggle/tag/service/CategoryServiceTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/tag/service/CategoryServiceTest.java
@@ -67,18 +67,18 @@ class CategoryServiceTest {
         assertThat(categoryResponse.getTitle()).isEqualTo("project");
     }
 
-    @DisplayName("createCategory: 중복된 카테고리가 존재하는 경우 이미 존재하는 카테고리를 반환한다.")
+    @DisplayName("createCategory: 이미 같은 이름의 카테고리가 존재하는 경우, 기존의 카테고리를 반환한다.")
     @Test
     void createCategory_CategoryDuplicationException() {
         // given
         final CategoryRequest categoryRequest = new CategoryRequest("project");
 
         // when
-        categoryService.createCategory(user, categoryRequest);
         final CategoryResponse categoryResponse = categoryService.createCategory(user, categoryRequest);
+        final CategoryResponse categoryResponseWithSameName = categoryService.createCategory(user, categoryRequest);
         // then
-        assertThat(categoryResponse.getId()).isNotNull();
-        assertThat(categoryResponse.getTitle()).isEqualTo("project");
+        assertThat(categoryResponse.getId()).isEqualTo(categoryResponseWithSameName.getId());
+        assertThat(categoryResponse.getTitle()).isEqualTo(categoryResponseWithSameName.getTitle());
     }
 
     @DisplayName("findAllTagsBy: 카테고리를 포함한 모든 태그를 가져온다.")

--- a/backend/core/src/test/java/com/woowacourse/taggle/tag/service/CategoryServiceTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/tag/service/CategoryServiceTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.woowacourse.taggle.JpaTestConfiguration;
+import com.woowacourse.taggle.setup.domain.UserFixture;
 import com.woowacourse.taggle.tag.domain.Category;
 import com.woowacourse.taggle.tag.domain.CategoryRepository;
 import com.woowacourse.taggle.tag.domain.Tag;
@@ -23,7 +24,6 @@ import com.woowacourse.taggle.tag.dto.CategoryTagsResponse;
 import com.woowacourse.taggle.tag.dto.TagCreateRequest;
 import com.woowacourse.taggle.tag.dto.TagResponse;
 import com.woowacourse.taggle.tag.exception.CategoryNotFoundException;
-import com.woowacourse.taggle.user.domain.Role;
 import com.woowacourse.taggle.user.domain.User;
 import com.woowacourse.taggle.user.dto.SessionUser;
 import com.woowacourse.taggle.user.service.UserService;
@@ -49,12 +49,7 @@ class CategoryServiceTest {
 
     @BeforeEach
     void setUp() {
-        final User testUser = userService.save(User.builder()
-                .email("a@a.com")
-                .nickName("tigger")
-                .role(Role.USER)
-                .picture("https://www.naver.com/")
-                .build());
+        final User testUser = userService.save(UserFixture.DEFAULT_USER);
         user = new SessionUser(testUser);
     }
 

--- a/backend/core/src/test/java/com/woowacourse/taggle/tag/service/CategoryServiceTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/tag/service/CategoryServiceTest.java
@@ -14,7 +14,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.woowacourse.taggle.JpaTestConfiguration;
-import com.woowacourse.taggle.setup.domain.UserFixture;
+import com.woowacourse.taggle.fixture.UserFixture;
 import com.woowacourse.taggle.tag.domain.Category;
 import com.woowacourse.taggle.tag.domain.CategoryRepository;
 import com.woowacourse.taggle.tag.domain.Tag;

--- a/backend/core/src/test/java/com/woowacourse/taggle/tag/service/TagBookmarkServiceTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/tag/service/TagBookmarkServiceTest.java
@@ -12,7 +12,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.woowacourse.taggle.JpaTestConfiguration;
-import com.woowacourse.taggle.setup.domain.UserFixture;
+import com.woowacourse.taggle.fixture.UserFixture;
 import com.woowacourse.taggle.tag.dto.BookmarkCreateDto;
 import com.woowacourse.taggle.tag.dto.BookmarkResponse;
 import com.woowacourse.taggle.tag.dto.TagBookmarkResponse;

--- a/backend/core/src/test/java/com/woowacourse/taggle/tag/service/TagBookmarkServiceTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/tag/service/TagBookmarkServiceTest.java
@@ -12,12 +12,12 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.woowacourse.taggle.JpaTestConfiguration;
+import com.woowacourse.taggle.setup.domain.UserFixture;
 import com.woowacourse.taggle.tag.dto.BookmarkCreateDto;
 import com.woowacourse.taggle.tag.dto.BookmarkResponse;
 import com.woowacourse.taggle.tag.dto.TagBookmarkResponse;
 import com.woowacourse.taggle.tag.dto.TagCreateRequest;
 import com.woowacourse.taggle.tag.dto.TagResponse;
-import com.woowacourse.taggle.user.domain.Role;
 import com.woowacourse.taggle.user.domain.User;
 import com.woowacourse.taggle.user.dto.SessionUser;
 import com.woowacourse.taggle.user.service.UserService;
@@ -43,12 +43,7 @@ class TagBookmarkServiceTest {
 
     @BeforeEach
     void setUp() {
-        final User testUser = userService.save(User.builder()
-                .email("a@a.com")
-                .nickName("tigger")
-                .role(Role.USER)
-                .picture("https://www.naver.com/")
-                .build());
+        final User testUser = userService.save(UserFixture.DEFAULT_USER);
         user = new SessionUser(testUser);
     }
 

--- a/backend/core/src/test/java/com/woowacourse/taggle/tag/service/TagServiceTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/tag/service/TagServiceTest.java
@@ -12,7 +12,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.woowacourse.taggle.JpaTestConfiguration;
-import com.woowacourse.taggle.setup.domain.UserFixture;
+import com.woowacourse.taggle.fixture.UserFixture;
 import com.woowacourse.taggle.tag.domain.TagRepository;
 import com.woowacourse.taggle.tag.dto.TagBookmarkResponse;
 import com.woowacourse.taggle.tag.dto.TagCreateRequest;

--- a/backend/core/src/test/java/com/woowacourse/taggle/tag/service/TagServiceTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/tag/service/TagServiceTest.java
@@ -59,19 +59,19 @@ class TagServiceTest {
         assertThat(tagResponse.getName()).isEqualTo(TAG_NAME);
     }
 
-    @DisplayName("createTag: 중복된 태그가 존재하는 경우 이미 존재하는 태그를 반환한다.")
+    @DisplayName("createTag: 이미 같은 이름의 태그가 존재하는 경우, 기존의 태그를 반환한다.")
     @Test
     void createTag_TagAlreadyExist_ReturnExistTag() {
         // given
         final TagCreateRequest tagCreateRequest = new TagCreateRequest(TAG_NAME);
 
         // when
-        tagService.createTag(user, tagCreateRequest);
         final TagResponse tagResponse = tagService.createTag(user, tagCreateRequest);
+        final TagResponse tagResponseWithSameName = tagService.createTag(user, tagCreateRequest);
 
         // then
-        assertThat(tagResponse.getId()).isNotNull();
-        assertThat(tagResponse.getName()).isEqualTo(TAG_NAME);
+        assertThat(tagResponse.getId()).isEqualTo(tagResponseWithSameName.getId());
+        assertThat(tagResponse.getName()).isEqualTo(tagResponseWithSameName.getName());
     }
 
     @DisplayName("findTagById: 특정 태그를 조회한다.")

--- a/backend/core/src/test/java/com/woowacourse/taggle/tag/service/TagServiceTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/tag/service/TagServiceTest.java
@@ -12,12 +12,12 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.woowacourse.taggle.JpaTestConfiguration;
+import com.woowacourse.taggle.setup.domain.UserFixture;
 import com.woowacourse.taggle.tag.domain.TagRepository;
 import com.woowacourse.taggle.tag.dto.TagBookmarkResponse;
 import com.woowacourse.taggle.tag.dto.TagCreateRequest;
 import com.woowacourse.taggle.tag.dto.TagResponse;
 import com.woowacourse.taggle.tag.exception.TagNotFoundException;
-import com.woowacourse.taggle.user.domain.Role;
 import com.woowacourse.taggle.user.domain.User;
 import com.woowacourse.taggle.user.dto.SessionUser;
 import com.woowacourse.taggle.user.service.UserService;
@@ -32,9 +32,6 @@ class TagServiceTest {
     private TagService tagService;
 
     @Autowired
-    private CategoryService categoryService;
-
-    @Autowired
     private UserService userService;
 
     @Autowired
@@ -44,12 +41,7 @@ class TagServiceTest {
 
     @BeforeEach
     void setUp() {
-        final User testUser = userService.save(User.builder()
-                .email("a@a.com")
-                .nickName("tigger")
-                .role(Role.USER)
-                .picture("https://www.naver.com/")
-                .build());
+        final User testUser = userService.save(UserFixture.DEFAULT_USER);
         user = new SessionUser(testUser);
     }
 

--- a/backend/core/src/test/java/com/woowacourse/taggle/user/domain/UserRepositoryTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/user/domain/UserRepositoryTest.java
@@ -12,7 +12,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
 
 import com.woowacourse.taggle.JpaTestConfiguration;
-import com.woowacourse.taggle.setup.domain.UserFixture;
+import com.woowacourse.taggle.fixture.UserFixture;
 
 @DataJpaTest
 @ContextConfiguration(classes = JpaTestConfiguration.class)
@@ -28,7 +28,7 @@ class UserRepositoryTest {
         user = UserFixture.DEFAULT_USER;
     }
 
-    @DisplayName("save(): 유저 저장 확인 테스트")
+    @DisplayName("save: 유저 저장 확인 테스트")
     @Test
     void save() {
         // when
@@ -38,12 +38,12 @@ class UserRepositoryTest {
         assertThat(actual).isNotNull();
     }
 
-    @DisplayName("findByEmail(): 이메일로 유저 찾기 테스트")
+    @DisplayName("findByEmail: 이메일로 유저 찾기 테스트")
     @Test
     void findByEmail() {
         // when
-        User user1 = userRepository.save(user);
-        final Optional<User> actual = userRepository.findById(user1.getId());
+        User newUser = userRepository.save(user);
+        final Optional<User> actual = userRepository.findById(newUser.getId());
 
         // then
         assertThat(actual).isNotEmpty();

--- a/backend/core/src/test/java/com/woowacourse/taggle/user/domain/UserRepositoryTest.java
+++ b/backend/core/src/test/java/com/woowacourse/taggle/user/domain/UserRepositoryTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
 
 import com.woowacourse.taggle.JpaTestConfiguration;
+import com.woowacourse.taggle.setup.domain.UserFixture;
 
 @DataJpaTest
 @ContextConfiguration(classes = JpaTestConfiguration.class)
@@ -24,8 +25,7 @@ class UserRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        user = new User(1L,"태글", "taggle@gmail.com", "010-0000-0000",
-                "https://github.com/image.jpg", Role.USER);
+        user = UserFixture.DEFAULT_USER;
     }
 
     @DisplayName("save(): 유저 저장 확인 테스트")

--- a/backend/web/src/docs/asciidoc/api-guide.adoc
+++ b/backend/web/src/docs/asciidoc/api-guide.adoc
@@ -19,7 +19,7 @@ endif::[]
 [[resources-categories-create]]
 === 카테고리 추가
 
-operation::categories/create[snippets='http-request,request-body,http-response,response-headers,response-body']
+operation::categories/create[snippets='http-request,request-fields,http-response,response-headers,response-fields']
 
 [[resources-categories-get-list]]
 === 카테고리 전체 조회
@@ -34,12 +34,12 @@ operation::categories/update[snippets='http-request,request-fields,http-response
 [[resources-categories-tags-update]]
 === 태그의 카테고리 수정
 
-operation::categories/tags/update[snippets='http-request,http-response,path-parameters']
+operation::categories/tags/update[snippets='http-request,path-parameters,http-response']
 
 [[resources-categories-delete]]
 === 카테고리 삭제
 
-operation::categories/delete[snippets='http-request,http-response,path-parameters']
+operation::categories/delete[snippets='http-request,path-parameters,http-response']
 
 [[resources-tags]]
 == Tags
@@ -47,12 +47,12 @@ operation::categories/delete[snippets='http-request,http-response,path-parameter
 [[resources-tags-create]]
 === 태그 추가
 
-operation::tags/create[snippets='http-request,request-fields,http-response,response-headers,response-body']
+operation::tags/create[snippets='http-request,request-fields,http-response,response-headers,response-fields']
 
 [[resources-tags-get]]
 === 태그 조회
 
-operation::tags/get[snippets='http-request,http-response,response-fields']
+operation::tags/get[snippets='http-request,path-parameters,http-response,response-fields']
 
 [[resources-tags-delete]]
 === 태그 삭제
@@ -75,7 +75,7 @@ operation::tags/bookmarks/delete[snippets='http-request,path-parameters,http-res
 [[resources-bookmarks-create]]
 === 북마크 추가
 
-operation::bookmarks/create[snippets='http-request,request-fields,http-response,response-headers']
+operation::bookmarks/create[snippets='http-request,request-fields,http-response,response-headers,response-fields']
 
 [[resources-bookmarks-get]]
 === 특정 북마크 조회

--- a/backend/web/src/test/java/com/woowacourse/taggle/acceptance/BookmarkAcceptanceTest.java
+++ b/backend/web/src/test/java/com/woowacourse/taggle/acceptance/BookmarkAcceptanceTest.java
@@ -25,6 +25,12 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         List<BookmarkResponse> bookmarks = findBookmarks();
 
         assertThat(bookmarks).hasSize(1);
+
+        // 기존에 존재하는 북마크와 동일한 이름의 북마크를 생성요청시, 새 북마크를 생성하지 않는다.
+        createBookmark("http://naver.com");
+        bookmarks = findBookmarks();
+
+        assertThat(bookmarks).hasSize(1);
         
         // 태그에 북마크를 추가한다.
         final Long bookmarkId = bookmarks.get(0).getId();

--- a/backend/web/src/test/java/com/woowacourse/taggle/acceptance/CategoryAcceptanceTest.java
+++ b/backend/web/src/test/java/com/woowacourse/taggle/acceptance/CategoryAcceptanceTest.java
@@ -25,6 +25,12 @@ public class CategoryAcceptanceTest extends AcceptanceTest {
         List<CategoryTagsResponse> categories = findCategories();
         assertThat(categories).hasSize(1);
 
+        // 이미 존재하는 카테고리와 같은 이름의 카테고리 생성요청시 새 카테고리를 생성하지 않는다.
+        createCategory("project");
+        categories = findCategories();
+
+        assertThat(categories).hasSize(1);
+
         // 카테고리를 수정한다.
         final Long categoryId = categories.get(0).getId();
         final String updateTitle = "service";

--- a/backend/web/src/test/java/com/woowacourse/taggle/acceptance/TagAcceptanceTest.java
+++ b/backend/web/src/test/java/com/woowacourse/taggle/acceptance/TagAcceptanceTest.java
@@ -28,6 +28,12 @@ public class TagAcceptanceTest extends AcceptanceTest {
 
         assertThat(tagBookmarkResponse.getName()).isEqualTo("taggle");
 
+        // 이미 존재하는 태그와 같은 이름의 태그 생성요청시 새 태그를 생성하지 않는다.
+        TagResponse taggleWithSameName = createTag("taggle");
+        TagBookmarkResponse tagBookmarkResponseWithSameName = findTagById(taggleWithSameName.getId());
+
+        assertThat(tagBookmarkResponse.getId()).isEqualTo(tagBookmarkResponseWithSameName.getId());
+
         // 북마크에 태그를 추가한다
         final Long tagId = tagBookmarkResponse.getId();
 

--- a/backend/web/src/test/java/com/woowacourse/taggle/setup/domain/UserSetup.java
+++ b/backend/web/src/test/java/com/woowacourse/taggle/setup/domain/UserSetup.java
@@ -16,7 +16,7 @@ public class UserSetup {
     public User save() {
         final User user = User.builder()
                 .id(1L)
-                .email("a@a.com")
+                .email("jordyLover@kakao.com")
                 .nickName("tigger")
                 .role(Role.USER)
                 .picture("https://www.naver.com/")

--- a/backend/web/src/test/java/com/woowacourse/taggle/tag/controller/docs/BookmarkDocumentation.java
+++ b/backend/web/src/test/java/com/woowacourse/taggle/tag/controller/docs/BookmarkDocumentation.java
@@ -17,6 +17,13 @@ public class BookmarkDocumentation {
                 ),
                 responseHeaders(
                         headerWithName("Location").description("생성된 북마크의 URI")
+                ),
+                responseFields(
+                        fieldWithPath("id").description("북마크 ID"),
+                        fieldWithPath("url").description("북마크 URL"),
+                        fieldWithPath("title").description("북마크 타이틀"),
+                        fieldWithPath("description").description("북마크 설명"),
+                        fieldWithPath("image").description("북마크 이미지")
                 )
         );
     }

--- a/backend/web/src/test/java/com/woowacourse/taggle/tag/controller/docs/TagDocumentation.java
+++ b/backend/web/src/test/java/com/woowacourse/taggle/tag/controller/docs/TagDocumentation.java
@@ -16,6 +16,10 @@ public class TagDocumentation {
                 ),
                 responseHeaders(
                         headerWithName("Location").description("생성된 태그의 URI")
+                ),
+                responseFields(
+                        fieldWithPath("id").description("태그 ID"),
+                        fieldWithPath("name").description("태그 이름")
                 )
         );
     }


### PR DESCRIPTION
- 중복 생성 요청 관련 인수테스트 추가, 생성 API 문서 Response Fields 추가또한 수행했습니다. 

resolve #148 