### PR TITLE
feat(aop): AOP 적용 (#232)

### DIFF
--- a/backend/taggle-web/src/main/java/kr/taggle/aop/ControllerLoggingAspect.java
+++ b/backend/taggle-web/src/main/java/kr/taggle/aop/ControllerLoggingAspect.java
@@ -1,0 +1,67 @@
+package kr.taggle.aop;
+
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import net.minidev.json.JSONObject;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Aspect
+@Slf4j
+@Component
+public class ControllerLoggingAspect {
+
+    private static JSONObject getParams(final HttpServletRequest request) {
+        final JSONObject jsonObject = new JSONObject();
+        final Enumeration<String> params = request.getParameterNames();
+        while (params.hasMoreElements()) {
+            final String param = params.nextElement();
+            final String replaceParam = param.replaceAll("\\.", "-");
+            jsonObject.put(replaceParam, request.getParameter(param));
+        }
+        return jsonObject;
+    }
+
+    @Pointcut("execution(* kr.taggle..controller..*Controller.*(..))")
+    public void logPointCut() {
+    }
+
+    @Around("logPointCut()")
+    public Object logAround(final ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        Object result = null;
+
+        try {
+            final long start = System.currentTimeMillis();
+            result = proceedingJoinPoint.proceed();
+            final long end = System.currentTimeMillis();
+
+            final HttpServletRequest request = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest();
+            final String controllerName = proceedingJoinPoint.getSignature().getDeclaringType().getSimpleName();
+            final String methodName = proceedingJoinPoint.getSignature().getName();
+
+            final Map<String, Object> params = new HashMap<>();
+            params.put("controller", controllerName);
+            params.put("method", methodName);
+            params.put("params", getParams(request));
+            params.put("request_uri", request.getRequestURI());
+            params.put("http_method", request.getMethod());
+            params.put("execution_time", end - start + "ms");
+            log.info("params : {}", params);
+        } catch (final Exception e) {
+            log.error("LoggingAspect error" + e.getMessage());
+        }
+        return result;
+    }
+}

--- a/backend/taggle-web/src/main/java/kr/taggle/aop/ControllerLoggingAspect.java
+++ b/backend/taggle-web/src/main/java/kr/taggle/aop/ControllerLoggingAspect.java
@@ -40,13 +40,11 @@ public class ControllerLoggingAspect {
 
     @Around("logPointCut()")
     public Object logAround(final ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
-        Object result = null;
+        final long start = System.currentTimeMillis();
+        final Object result = proceedingJoinPoint.proceed();
+        final long end = System.currentTimeMillis();
 
         try {
-            final long start = System.currentTimeMillis();
-            result = proceedingJoinPoint.proceed();
-            final long end = System.currentTimeMillis();
-
             final HttpServletRequest request = ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes()).getRequest();
             final String controllerName = proceedingJoinPoint.getSignature().getDeclaringType().getSimpleName();
             final String methodName = proceedingJoinPoint.getSignature().getName();

--- a/backend/taggle-web/src/main/java/kr/taggle/common/config/AopConfig.java
+++ b/backend/taggle-web/src/main/java/kr/taggle/common/config/AopConfig.java
@@ -1,0 +1,9 @@
+package kr.taggle.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+@Configuration
+@EnableAspectJAutoProxy
+public class AopConfig {
+}

--- a/backend/taggle-web/src/main/java/kr/taggle/common/controller/ApiControllerAdvice.java
+++ b/backend/taggle-web/src/main/java/kr/taggle/common/controller/ApiControllerAdvice.java
@@ -21,7 +21,7 @@ public class ApiControllerAdvice {
 
     @ExceptionHandler(TagNotFoundException.class)
     public ResponseEntity<String> handleTagNotFoundException(final Exception exception) {
-        log.error(exception.getMessage());
+        log.info(exception.getMessage());
 
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
@@ -30,7 +30,7 @@ public class ApiControllerAdvice {
 
     @ExceptionHandler(BookmarkNotFoundException.class)
     public ResponseEntity<String> handleBookmarkNotFoundException(final Exception exception) {
-        log.error(exception.getMessage());
+        log.info(exception.getMessage());
 
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
@@ -39,7 +39,7 @@ public class ApiControllerAdvice {
 
     @ExceptionHandler(TagBookmarkNotFoundException.class)
     public ResponseEntity<String> handleTagBookmarkNotFoundException(final Exception exception) {
-        log.error(exception.getMessage());
+        log.info(exception.getMessage());
 
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
@@ -48,7 +48,7 @@ public class ApiControllerAdvice {
 
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<String> handleUserNotFoundException(final Exception exception) {
-        log.error(exception.getMessage());
+        log.info(exception.getMessage());
 
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
@@ -57,7 +57,7 @@ public class ApiControllerAdvice {
 
     @ExceptionHandler(CrawlerConnectionException.class)
     public ResponseEntity<String> crawlerConnectionException(final CrawlerConnectionException exception) {
-        log.error(exception.getMessage());
+        log.info(exception.getMessage());
 
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
@@ -66,7 +66,7 @@ public class ApiControllerAdvice {
 
     @ExceptionHandler(InvalidURLException.class)
     public ResponseEntity<String> InvalidURLException(final InvalidURLException exception) {
-        log.error(exception.getMessage());
+        log.info(exception.getMessage());
 
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
@@ -84,7 +84,7 @@ public class ApiControllerAdvice {
 
     @ExceptionHandler(AuthenticationException.class)
     public ResponseEntity<String> authenticationException(final AuthenticationException authenticationException) {
-        log.error(authenticationException.getMessage());
+        log.info(authenticationException.getMessage());
 
         return ResponseEntity
                 .status(HttpStatus.UNAUTHORIZED)

--- a/backend/taggle-web/src/test/java/kr/taggle/acceptance/TagAcceptanceTest.java
+++ b/backend/taggle-web/src/test/java/kr/taggle/acceptance/TagAcceptanceTest.java
@@ -9,16 +9,16 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
 
-import kr.taggle.bookmark.dto.TagBookmarkResponse;
-import kr.taggle.tag.dto.TagResponse;
 import io.restassured.module.mockmvc.response.MockMvcResponse;
 import io.restassured.response.ExtractableResponse;
+import kr.taggle.bookmark.dto.TagBookmarkResponse;
+import kr.taggle.tag.dto.TagResponse;
 
 public class TagAcceptanceTest extends AcceptanceTest {
 
     @Transactional
     @Test
-    void manageBookmark() {
+    void manageTag() {
         // 태그를 생성한다
         final TagResponse tagResponse = createTag("taggle");
 


### PR DESCRIPTION
resolve #232 

적용 내용은 컨트롤러 실행 전, 후의 시간을 측정하여 info 레벨로 로그를 출력하는겁니다.
우선 ControllerAdvice에는 적용하지 않고 Controller에만 적용했습니다.
ControllerAdvice에는 interceptor 또는 handler를 이용해야 할 것 같아 일단 제외했습니다.

설정 방법과 관련해서는 아래 글 참고하세요.
https://www.notion.so/kskim/AspectJ-AOP-25e9795c1a47473e83f01ae5576cd647