### PR TITLE
fix(uri): api 권한 확인용 api uri 오탈자 수정 (/api/v1//me -> /api/v1/me)

### DIFF
--- a/backend/taggle-web/src/main/java/kr/taggle/security/config/WebSecurityConfig.java
+++ b/backend/taggle-web/src/main/java/kr/taggle/security/config/WebSecurityConfig.java
@@ -35,7 +35,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
         http
                 .authorizeRequests()
-                        .antMatchers("/", "/signin","/h2-console/**","/api/v1//me").permitAll()
+                        .antMatchers("/", "/signin","/h2-console/**","/api/v1/me").permitAll()
                         .antMatchers("/api/**").hasRole("USER")
                         .antMatchers("/docs/**").hasRole("ADMIN")
                 .anyRequest().authenticated()


### PR DESCRIPTION
resolves #257

---
URI 리팩토링 작업 (#231 ) 중에 `/` 부호를 실수로 제거하지 않았습니다.
이로 인해 유저의 권한 확인이 제대로 이뤄지지 않아 페이지 진입 실패 혹은 로그인 실패 하는 현상이 나타났습니다. 
번거롭게 해 죄송합니다. 🥺  
꼼꼼한 확인을 위해 taggle 프로젝트의 backend 폴더 기준 빌드 후 실행을 통한 확인 부탁 드립니다. 

```sh
./gradlew clean build

java -jar taggle-web/build/libs/taggle-web-0.0.1-SNAPSHOT.jar&
```