### PR TITLE
fix(oauth): 카카오 로그인이 되지 않는 버그 해결 (#224)

### DIFF
--- a/backend/taggle-core/src/main/java/kr/taggle/user/dto/OAuthAttributes.java
+++ b/backend/taggle-core/src/main/java/kr/taggle/user/dto/OAuthAttributes.java
@@ -1,6 +1,7 @@
 package kr.taggle.user.dto;
 
 import java.util.Map;
+import java.util.Objects;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
@@ -75,12 +76,12 @@ public class OAuthAttributes {
                 .build();
     }
 
-    private static String getPicture(final String profile_image_url) {
-        if (profile_image_url == null) {
+    private static String getPicture(final String profileImageUrl) {
+        if (Objects.isNull(profileImageUrl)) {
             return "https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_1280.png";
         }
 
-        return profile_image_url;
+        return profileImageUrl;
     }
 
     public User toEntity() {

--- a/backend/taggle-core/src/main/java/kr/taggle/user/dto/OAuthAttributes.java
+++ b/backend/taggle-core/src/main/java/kr/taggle/user/dto/OAuthAttributes.java
@@ -69,10 +69,18 @@ public class OAuthAttributes {
         return OAuthAttributes.builder()
                 .nickName((String)profile.get("nickname"))
                 .email((String)response.get("email"))
-                .picture((String)profile.get("profile_image_url"))
+                .picture(getPicture((String)profile.get("profile_image_url")))
                 .attributes(attributes)
                 .nameAttributeKey(userNameAttributeName)
                 .build();
+    }
+
+    private static String getPicture(final String profile_image_url) {
+        if (profile_image_url == null) {
+            return "https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_1280.png";
+        }
+
+        return profile_image_url;
     }
 
     public User toEntity() {

--- a/backend/taggle-web/src/main/java/kr/taggle/authentication/UserArgumentResolver.java
+++ b/backend/taggle-web/src/main/java/kr/taggle/authentication/UserArgumentResolver.java
@@ -1,11 +1,13 @@
 package kr.taggle.authentication;
 
+import java.util.Map;
+
 import javax.naming.AuthenticationException;
 
 import org.springframework.core.MethodParameter;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -35,7 +37,8 @@ public class UserArgumentResolver implements HandlerMethodArgumentResolver {
     @Override
     public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
             final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) throws Exception {
-        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        final OAuth2AuthenticationToken authentication = (OAuth2AuthenticationToken)SecurityContextHolder.getContext()
+                .getAuthentication();
         if (authentication.getPrincipal().equals("anonymousUser")) {
             throw new AuthenticationException("인증하지 않은 사용자입니다");
         }
@@ -43,10 +46,24 @@ public class UserArgumentResolver implements HandlerMethodArgumentResolver {
         return getUser(authentication);
     }
 
-    private SessionUser getUser(final Authentication authentication) {
+    private SessionUser getUser(final OAuth2AuthenticationToken authentication) {
         final DefaultOAuth2User defaultOAuth2User = (DefaultOAuth2User)authentication.getPrincipal();
-        final User user = userRepository.findByEmail(defaultOAuth2User.getAttributes().get("email").toString())
-                .orElseThrow(() -> new UserNotFoundException("사용자가 존재하지 않습니다."));
+
+        final User user = getUserWithRegistrationId(authentication.getAuthorizedClientRegistrationId(),
+                defaultOAuth2User);
         return new SessionUser(user);
+    }
+
+    public User getUserWithRegistrationId(final String registrationId, final DefaultOAuth2User defaultOAuth2User) {
+        if ("kakao".equals(registrationId)) {
+            final Map<String, Object> kakao_acount = (Map<String, Object>)defaultOAuth2User.getAttributes()
+                    .get("kakao_account");
+
+            return userRepository.findByEmail(kakao_acount.get("email").toString())
+                    .orElseThrow(() -> new UserNotFoundException("사용자가 존재하지 않습니다."));
+        }
+
+        return userRepository.findByEmail(defaultOAuth2User.getAttributes().get("email").toString())
+                .orElseThrow(() -> new UserNotFoundException("사용자가 존재하지 않습니다."));
     }
 }

--- a/backend/taggle-web/src/main/java/kr/taggle/authentication/UserArgumentResolver.java
+++ b/backend/taggle-web/src/main/java/kr/taggle/authentication/UserArgumentResolver.java
@@ -24,6 +24,10 @@ import kr.taggle.user.exception.UserNotFoundException;
 @Component
 public class UserArgumentResolver implements HandlerMethodArgumentResolver {
 
+    private static final String EMAIL = "email";
+    private static final String KAKAO = "kakao";
+    private static final String ANONYMOUS_USER = "anonymousUser";
+
     private final UserRepository userRepository;
 
     public UserArgumentResolver(final UserRepository userRepository) {
@@ -40,7 +44,7 @@ public class UserArgumentResolver implements HandlerMethodArgumentResolver {
             final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) throws Exception {
         final Authentication authentication = SecurityContextHolder.getContext()
                 .getAuthentication();
-        if (authentication.getPrincipal().equals("anonymousUser")) {
+        if (authentication.getPrincipal().equals(ANONYMOUS_USER)) {
             throw new AuthenticationException("인증하지 않은 사용자입니다");
         }
 
@@ -58,15 +62,15 @@ public class UserArgumentResolver implements HandlerMethodArgumentResolver {
     }
 
     private User getUserWithRegistrationId(final String registrationId, final DefaultOAuth2User defaultOAuth2User) {
-        if ("kakao".equals(registrationId)) {
+        if (KAKAO.equals(registrationId)) {
             final Map<String, Object> kakaoAcount = (Map<String, Object>)defaultOAuth2User.getAttributes()
                     .get("kakao_account");
 
-            return userRepository.findByEmail(kakaoAcount.get("email").toString())
+            return userRepository.findByEmail(kakaoAcount.get(EMAIL).toString())
                     .orElseThrow(() -> new UserNotFoundException("사용자가 존재하지 않습니다."));
         }
 
-        return userRepository.findByEmail(defaultOAuth2User.getAttributes().get("email").toString())
+        return userRepository.findByEmail(defaultOAuth2User.getAttributes().get(EMAIL).toString())
                 .orElseThrow(() -> new UserNotFoundException("사용자가 존재하지 않습니다."));
     }
 }

--- a/backend/taggle-web/src/main/java/kr/taggle/security/config/WebSecurityConfig.java
+++ b/backend/taggle-web/src/main/java/kr/taggle/security/config/WebSecurityConfig.java
@@ -1,5 +1,10 @@
 package kr.taggle.security.config;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpMethod;
@@ -7,10 +12,15 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.oauth2.client.CommonOAuth2Provider;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import kr.taggle.security.provider.CustomOAuth2Provider;
 import kr.taggle.security.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 
@@ -63,5 +73,33 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         corsConfiguration.addExposedHeader("Location");
         source.registerCorsConfiguration("/**", corsConfiguration);
         return source;
+    }
+
+    @Bean
+    public ClientRegistrationRepository clientRegistrationRepository(
+            final OAuth2ClientProperties oAuth2ClientProperties,
+            @Value("${spring.security.oauth2.client.registration.kakao.client-id}")final String kakaoClientId,
+            @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")final String kakaoSecretId){
+
+        final List<ClientRegistration> registrations = new ArrayList<>();
+
+        final OAuth2ClientProperties.Registration registration = oAuth2ClientProperties.getRegistration().get("google");
+
+        registrations.add(
+                CommonOAuth2Provider.GOOGLE.getBuilder("google")
+                .clientId(registration.getClientId())
+                .clientSecret(registration.getClientSecret())
+                .scope("email", "profile")
+                .build()
+        );
+
+        registrations.add(
+                CustomOAuth2Provider.KAKAO.getBuilder("kakao")
+                .clientId(kakaoClientId)
+                .clientSecret(kakaoSecretId)
+                .build()
+        );
+
+        return new InMemoryClientRegistrationRepository(registrations);
     }
 }

--- a/backend/taggle-web/src/main/java/kr/taggle/security/config/WebSecurityConfig.java
+++ b/backend/taggle-web/src/main/java/kr/taggle/security/config/WebSecurityConfig.java
@@ -45,7 +45,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
         http
                 .authorizeRequests()
-                        .antMatchers("/", "/signin","/h2-console/**","/api/v1//me").permitAll()
+                        .antMatchers("/", "/signin","/h2-console/**","/api/v1/me").permitAll()
                         .antMatchers("/api/**").hasRole("USER")
                         .antMatchers("/docs/**").hasRole("ADMIN")
                 .anyRequest().authenticated()

--- a/backend/taggle-web/src/main/java/kr/taggle/security/config/WebSecurityConfig.java
+++ b/backend/taggle-web/src/main/java/kr/taggle/security/config/WebSecurityConfig.java
@@ -3,7 +3,6 @@ package kr.taggle.security.config;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -28,6 +27,9 @@ import lombok.RequiredArgsConstructor;
 @EnableWebSecurity
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
+    private static final String KAKAO = "kakao";
+    private static final String GOOGLE = "google";
+
     private final CustomOAuth2UserService customOAuth2UserService;
 
     @Override
@@ -40,12 +42,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(final HttpSecurity http) throws Exception {
         http
-                .csrf()
-                    .ignoringAntMatchers("/h2-console/**")
-                .and()
-                    .headers()
-                    .frameOptions()
-                    .sameOrigin();
+                .csrf().disable()
+                    .headers().frameOptions().sameOrigin();
 
         http
                 .authorizeRequests()
@@ -58,7 +56,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
                         .logout()
                         .logoutUrl("/oauth2/logout")
-                        .logoutSuccessUrl("/signin")
+                        .logoutSuccessUrl("/")
                         .deleteCookies("JSESSIONID")
                         .invalidateHttpSession(true)
                 .and()
@@ -81,26 +79,26 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Bean
     public ClientRegistrationRepository clientRegistrationRepository(
-            final OAuth2ClientProperties oAuth2ClientProperties,
-            @Value("${spring.security.oauth2.client.registration.kakao.client-id}")final String kakaoClientId,
-            @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")final String kakaoSecretId){
+            final OAuth2ClientProperties oAuth2ClientProperties){
 
         final List<ClientRegistration> registrations = new ArrayList<>();
 
-        final OAuth2ClientProperties.Registration registration = oAuth2ClientProperties.getRegistration().get("google");
+        OAuth2ClientProperties.Registration registration = oAuth2ClientProperties.getRegistration().get(GOOGLE);
 
         registrations.add(
-                CommonOAuth2Provider.GOOGLE.getBuilder("google")
+                CommonOAuth2Provider.GOOGLE.getBuilder(GOOGLE)
                 .clientId(registration.getClientId())
                 .clientSecret(registration.getClientSecret())
                 .scope("email", "profile")
                 .build()
         );
 
+        registration = oAuth2ClientProperties.getRegistration().get(KAKAO);
+
         registrations.add(
-                CustomOAuth2Provider.KAKAO.getBuilder("kakao")
-                .clientId(kakaoClientId)
-                .clientSecret(kakaoSecretId)
+                CustomOAuth2Provider.KAKAO.getBuilder(KAKAO)
+                .clientId(registration.getClientId())
+                .clientSecret(registration.getClientSecret())
                 .build()
         );
 

--- a/backend/taggle-web/src/main/java/kr/taggle/security/config/WebSecurityConfig.java
+++ b/backend/taggle-web/src/main/java/kr/taggle/security/config/WebSecurityConfig.java
@@ -40,8 +40,12 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(final HttpSecurity http) throws Exception {
         http
-                .csrf().disable()
-                .headers().frameOptions().disable();
+                .csrf()
+                    .ignoringAntMatchers("/h2-console/**")
+                .and()
+                    .headers()
+                    .frameOptions()
+                    .sameOrigin();
 
         http
                 .authorizeRequests()

--- a/backend/taggle-web/src/main/java/kr/taggle/security/provider/CustomOAuth2Provider.java
+++ b/backend/taggle-web/src/main/java/kr/taggle/security/provider/CustomOAuth2Provider.java
@@ -1,0 +1,39 @@
+package kr.taggle.security.provider;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+
+public enum CustomOAuth2Provider {
+
+    KAKAO {
+        @Override
+        public ClientRegistration.Builder getBuilder(final String registrationId) {
+            final ClientRegistration.Builder builder = getBuilder(registrationId, ClientAuthenticationMethod.POST,
+                    DEFAULT_LOGIN_REDIRECT_URL);
+
+            builder.authorizationUri("https://kauth.kakao.com/oauth/authorize");
+            builder.tokenUri("https://kauth.kakao.com/oauth/token");
+            builder.userInfoUri("https://kapi.kakao.com/v2/user/me");
+            builder.userNameAttributeName("id");
+            builder.clientName("Kakao");
+
+            return builder;
+        }
+    };
+
+    private static final String DEFAULT_LOGIN_REDIRECT_URL = "{baseUrl}/login/oauth2/code/{registrationId}";
+
+    protected ClientRegistration.Builder getBuilder(final String registrationId,
+            final ClientAuthenticationMethod method,
+            final String redirectUri) {
+        final ClientRegistration.Builder builder = ClientRegistration.withRegistrationId(registrationId);
+        builder.clientAuthenticationMethod(method);
+        builder.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE);
+        builder.redirectUriTemplate(redirectUri);
+
+        return builder;
+    }
+
+    public abstract ClientRegistration.Builder getBuilder(String registrationId);
+}

--- a/backend/taggle-web/src/main/java/kr/taggle/security/service/CustomOAuth2UserService.java
+++ b/backend/taggle-web/src/main/java/kr/taggle/security/service/CustomOAuth2UserService.java
@@ -2,10 +2,6 @@ package kr.taggle.security.service;
 
 import static java.util.Collections.*;
 
-import java.util.Optional;
-
-import javax.servlet.http.HttpSession;
-
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -19,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 import kr.taggle.user.domain.User;
 import kr.taggle.user.domain.UserRepository;
 import kr.taggle.user.dto.OAuthAttributes;
-import kr.taggle.user.dto.SessionUser;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -27,7 +22,6 @@ import lombok.RequiredArgsConstructor;
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
     private final UserRepository userRepository;
-    private final HttpSession httpSession;
 
     @Transactional
     @Override
@@ -45,17 +39,14 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                 oAuth2User.getAttributes());
         final User user = saveOrFind(attributes);
 
-        httpSession.setAttribute("user", new SessionUser(user));
-
         return new DefaultOAuth2User(singleton(new SimpleGrantedAuthority(user.getRole().getKey())),
                 attributes.getAttributes(),
                 attributes.getNameAttributeKey());
     }
 
     private User saveOrFind(final OAuthAttributes attributes) {
-        final Optional<User> user = userRepository.findByEmail(attributes.getEmail());
-
-        return user.orElseGet(() -> initialize(attributes));
+        return userRepository.findByEmail(attributes.getEmail())
+                .orElseGet(() -> initialize(attributes));
     }
 
     private User initialize(final OAuthAttributes attributes) {

--- a/backend/taggle-web/src/test/java/kr/taggle/security/config/WebSecurityConfigTest.java
+++ b/backend/taggle-web/src/test/java/kr/taggle/security/config/WebSecurityConfigTest.java
@@ -8,7 +8,7 @@ import io.restassured.RestAssured;
 
 @SpringBootTest(
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-        properties = "spring.config.location=classpath:/config/application-oauth.properties"
+        properties = "spring.config.location=classpath:/config/application-oauth.yml"
 )
 class WebSecurityConfigTest {
 

--- a/backend/taggle-web/src/test/resources/application.yml
+++ b/backend/taggle-web/src/test/resources/application.yml
@@ -7,11 +7,17 @@ spring:
     datasource.url: jdbc:h2:mem:testdb
   flyway:
     enabled: false
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: test
+            client-secret: test
+          kakao:
+            client-id: test
+            client-secret: test
 
 logging.level.org.hibernate.type.descriptor.sql: trace
 
-spring.security.oauth2.client.registration.google:
-  client-id: test
-  client-secret: test
-  scope: profile,email
 


### PR DESCRIPTION
resovle #224 

## 리뷰 시 확인사항
1. 카카오톡 로그인이 되는지 직접 로컬에서 실행해서 확인해주시면 감사하겠습니다.

## 해결한 사항
1. 프로필 사진이 없는 사용자는 프로필 사진에 대한("profile_image_url") 값이 들어오지 않았습니다. 이 부분을 null인 경우 기본 이미지로 들어가도록 설정해놨습니다. 기본 이미지는 S3가 구축되는 대로 변경하도록 하겠습니다.

2. Google OAuth2의 기본값들은 이미 spring-oauth2-client에서 제공을 해줍니다.
CommonOAuth2Provider Class 참고
따라서 서브모듈에서 있던 값들을 삭제하고 카카오톡 로그인도 커스텀으로 등록해놨습니다.

3. 카카오톡 로그인이 되지 않은 문제는 카카오는 email을 kakao-account 값에 있으나, 구글은 바로 가져올 수 있습니다.
따라서 그거에 맞춰서 리졸버에서 분기를 줬어야 하는데, 그렇게 되어있지 않아 로그인이 되지 않았습니다.

## 아직 남아 있는 문제점
1. 찾아보니 현재 서비스와 리졸버가 중복이 됩니다. 이 부분은 JWT로 리팩토링을 하면 자연스럽게 없어질거라고 생각은 듭니다.
